### PR TITLE
Add Travis CI build status to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# dosar
+# dosar [![Build Status](https://travis-ci.org/opensciencegrid/dosar.svg?branch=master)](https://travis-ci.org/opensciencegrid/dosar)


### PR DESCRIPTION
Hey Horst, related to your email, you can find the error that's preventing your updates from going through here:

https://travis-ci.org/opensciencegrid/dosar/jobs/504811969#L524

Basically the files you're referencing in mkdocs.yml don't exist. This commit adds a button to the README to indicate whether or not the Travis-CI publishing was successful or not (similar to [this](https://github.com/opensciencegrid/htcondor-ce/blob/master/README.md))